### PR TITLE
Fixed #57 which addresses an outdated OpenSSL version reference

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -99,7 +99,7 @@ Note: After you have installed the dependencies, you should check that the Brew 
 
         openssl version
 
-into Terminal. You should see OpenSSL 1.0.1e 11 Feb 2013.
+into Terminal. You should see OpenSSL 1.0.1e 11 Feb 2013 or newer version.
 
 If not, you can ensure that the Brew OpenSSL is correctly linked by running
 


### PR DESCRIPTION
A minor wording change to make it clear the user doesn't haven't to have that exact OpenSSL version.
