### PR TITLE
Updates to address DER length issue, OpenSSLv1.0.1K, adding dnsseed nodes

### DIFF
--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -16,7 +16,7 @@ packages:
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1h.tar.gz"
+- "openssl-1.0.1k.tar.gz"
 - "miniupnpc-1.8.tar.gz"
 - "qrencode-3.4.3.tar.bz2"
 - "db-4.8.30.NC.tar.gz"
@@ -29,14 +29,14 @@ script: |
   export TZ=UTC
   export LIBRARY_PATH="$STAGING/lib"
   # Integrity Check
-  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz"  | sha256sum -c
+  echo "8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c  openssl-1.0.1k.tar.gz"  | sha256sum -c
   echo "bc5f73c7b0056252c1888a80e6075787a1e1e9112b808f863a245483ff79859c  miniupnpc-1.8.tar.gz"   | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz"    | sha256sum -c
 
   #
-  tar xzf openssl-1.0.1h.tar.gz
-  cd openssl-1.0.1h
+  tar xzf openssl-1.0.1k.tar.gz
+  cd openssl-1.0.1k
   #   need -fPIC to avoid relocation error in 64 bit builds
   ./config no-shared no-zlib no-dso no-krb5 --openssldir=$STAGING -fPIC
   #   need to build OpenSSL with faketime because a timestamp is embedded into cversion.o
@@ -81,4 +81,4 @@ script: |
   done
   #
   cd $STAGING
-  find include lib bin host | sort | zip -X@ $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r3.zip
+  find include lib bin host | sort | zip -X@ $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r4.zip

--- a/contrib/gitian-descriptors/deps-win.yml
+++ b/contrib/gitian-descriptors/deps-win.yml
@@ -14,7 +14,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1h.tar.gz"
+- "openssl-1.0.1k.tar.gz"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.8.tar.gz"
 - "zlib-1.2.8.tar.gz"
@@ -28,7 +28,7 @@ script: |
   INDIR=$HOME/build
   TEMPDIR=$HOME/tmp
   # Input Integrity Check
-  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz"  | sha256sum -c
+  echo "8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c  openssl-1.0.1k.tar.gz"  | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz"    | sha256sum -c
   echo "bc5f73c7b0056252c1888a80e6075787a1e1e9112b808f863a245483ff79859c  miniupnpc-1.8.tar.gz"   | sha256sum -c
   echo "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d  zlib-1.2.8.tar.gz"      | sha256sum -c
@@ -48,8 +48,8 @@ script: |
     mkdir -p $INSTALLPREFIX $BUILDDIR
     cd $BUILDDIR
     #
-    tar xzf $INDIR/openssl-1.0.1h.tar.gz
-    cd openssl-1.0.1h
+    tar xzf $INDIR/openssl-1.0.1k.tar.gz
+    cd openssl-1.0.1k
     if [ "$BITS" == "32" ]; then
       OPENSSL_TGT=mingw
     else
@@ -124,5 +124,5 @@ script: |
     done
     #
     cd $INSTALLPREFIX
-    find include lib | sort | zip -X@ $OUTDIR/bitcoin-deps-win$BITS-gitian-r10.zip
+    find include lib | sort | zip -X@ $OUTDIR/bitcoin-deps-win$BITS-gitian-r11.zip
   done # for BITS in

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -21,8 +21,8 @@ remotes:
 - "url": "https://github.com/reddcoin-project/reddcoin.git"
   "dir": "reddcoin"
 files:
-- "bitcoin-deps-linux32-gitian-r3.zip"
-- "bitcoin-deps-linux64-gitian-r3.zip"
+- "bitcoin-deps-linux32-gitian-r4.zip"
+- "bitcoin-deps-linux64-gitian-r4.zip"
 - "boost-linux32-1.55.0-gitian-r1.zip"
 - "boost-linux64-1.55.0-gitian-r1.zip"
 script: |
@@ -36,7 +36,7 @@ script: |
   #
   mkdir -p $STAGING
   cd $STAGING
-  unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r3.zip
+  unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r4.zip
   unzip ../build/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
   cd ../build
   #

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -26,8 +26,8 @@ files:
 - "qt-win64-5.2.0-gitian-r2.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
 - "boost-win64-1.55.0-gitian-r6.zip"
-- "bitcoin-deps-win32-gitian-r10.zip"
-- "bitcoin-deps-win64-gitian-r10.zip"
+- "bitcoin-deps-win32-gitian-r11.zip"
+- "bitcoin-deps-win64-gitian-r11.zip"
 script: |
   # Defines
   export TZ=UTC
@@ -59,7 +59,7 @@ script: |
     cd $STAGING
     unzip $INDIR/qt-win${BITS}-5.2.0-gitian-r2.zip
     unzip $INDIR/boost-win${BITS}-1.55.0-gitian-r6.zip
-    unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r10.zip
+    unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r11.zip
     if [ "$NEEDDIST" == "1" ]; then
       # Make source code archive which is architecture independent so it only needs to be done once
       cd $HOME/build/reddcoin

--- a/contrib/gitian-descriptors/qt-win.yml
+++ b/contrib/gitian-descriptors/qt-win.yml
@@ -15,8 +15,8 @@ reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-5.2.0.tar.gz"
-- "bitcoin-deps-win32-gitian-r10.zip"
-- "bitcoin-deps-win64-gitian-r10.zip"
+- "bitcoin-deps-win32-gitian-r11.zip"
+- "bitcoin-deps-win64-gitian-r11.zip"
 script: |
   # Defines
   export TZ=UTC
@@ -48,7 +48,7 @@ script: |
     #
     # Need mingw-compiled openssl from bitcoin-deps:
     cd $DEPSDIR
-    unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r10.zip
+    unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r11.zip
     #
     cd $BUILDDIR
     #

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -22,7 +22,7 @@ Dependencies
 Libraries you need to download separately and build:
 
                 default path               download
-OpenSSL         \openssl-1.0.1g-mgw        http://www.openssl.org/source/
+OpenSSL         \openssl-1.0.1k-mgw        http://www.openssl.org/source/
 Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
 Boost           \boost-1.50.0-mgw          http://www.boost.org/users/download/
 miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
@@ -36,7 +36,7 @@ Their licenses:
 
 Versions used in this release:
 
-	OpenSSL      1.0.1g
+	OpenSSL      1.0.1k
 	Berkeley DB  4.8.30.NC
 	Boost        1.50.0
 	miniupnpc    1.6
@@ -49,7 +49,7 @@ MSYS shell:
 un-tar sources with MSYS 'tar xfz' to avoid issue with symlinks (OpenSSL ticket 2377)
 change 'MAKE' env. variable from 'C:\MinGW32\bin\mingw32-make.exe' to '/c/MinGW32/bin/mingw32-make.exe'
 
-	cd /c/openssl-1.0.1g-mgw
+	cd /c/openssl-1.0.1k-mgw
 	./config
 	make
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -46,7 +46,7 @@ Licenses of statically linked libraries:
 
 - Versions used in this release:
 -  GCC           4.3.3
--  OpenSSL       1.0.1c
+-  OpenSSL       1.0.1k
 -  Berkeley DB   4.8.30.NC
 -  Boost         1.37
 -  miniupnpc     1.6

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -45,7 +45,7 @@ Release Process
  Fetch the build dependencies
 
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.8.tar.gz' -O miniupnpc-1.8.tar.gz
-	wget 'https://www.openssl.org/source/openssl-1.0.1h.tar.gz'
+	wget 'https://www.openssl.org/source/openssl-1.0.1k.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
 	wget 'ftp://ftp.simplesystems.org/pub/png/src/history/libpng16/libpng-1.6.8.tar.gz'

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -201,11 +201,52 @@ public:
         return true;
     }
 
-    bool Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig) {
-        // -1 = error, 0 = bad sig, 1 = good
-        if (ECDSA_verify(0, (unsigned char*)&hash, sizeof(hash), &vchSig[0], vchSig.size(), pkey) != 1)
+    bool Verify(const uint256 &hash, const std::vector<unsigned char>& vchSigParam) {
+        // Prevent the problem described here: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-July/009697.html
+        // by removing the extra length bytes
+        std::vector<unsigned char> vchSig(vchSigParam.begin(), vchSigParam.end());
+        if (vchSig.size() > 1 && vchSig[1] & 0x80)
+        {
+            unsigned char nLengthBytes = vchSig[1] & 0x7f;
+            if (nLengthBytes > 4)
+            {
+                unsigned char nExtraBytes = nLengthBytes - 4;
+                for (unsigned char i = 0; i < nExtraBytes; i++)
+                    if (vchSig[2 + i])
+                        return false;
+                vchSig.erase(vchSig.begin() + 2, vchSig.begin() + 2 + nExtraBytes);
+                vchSig[1] = 0x80 | (nLengthBytes - nExtraBytes);
+            }
+        }
+
+        if (vchSig.empty())
             return false;
-        return true;
+
+        // New versions of OpenSSL will reject non-canonical DER signatures. de/re-serialize first.
+        unsigned char *norm_der = NULL;
+        ECDSA_SIG *norm_sig = ECDSA_SIG_new();
+        const unsigned char* sigptr = &vchSig[0];
+        assert(norm_sig);
+        if (d2i_ECDSA_SIG(&norm_sig, &sigptr, vchSig.size()) == NULL)
+        {
+            /* As of OpenSSL 1.0.0p d2i_ECDSA_SIG frees and nulls the pointer on
+             * error. But OpenSSL's own use of this function redundantly frees the
+             * result. As ECDSA_SIG_free(NULL) is a no-op, and in the absence of a
+             * clear contract for the function behaving the same way is more
+             * conservative.
+             */
+            ECDSA_SIG_free(norm_sig);
+            return false;
+        }
+        int derlen = i2d_ECDSA_SIG(norm_sig, &norm_der);
+        ECDSA_SIG_free(norm_sig);
+        if (derlen <= 0)
+            return false;
+
+        // -1 = error, 0 = bad sig, 1 = good
+        bool ret = ECDSA_verify(0, (unsigned char*)&hash, sizeof(hash), norm_der, derlen, pkey) == 1;
+        OPENSSL_free(norm_der);
+        return ret;
     }
 
     bool SignCompact(const uint256 &hash, unsigned char *p64, int &rec) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1197,11 +1197,13 @@ void MapPort(bool)
 // The second name should resolve to a list of seed addresses.
 static const char *strMainNetDNSSeed[][2] = {
     {"seed.reddcoin.com", "seed.reddcoin.com"},
+    {"dnsseed.redd.ink", "dnsseed.redd.ink"},
     {NULL, NULL}
 };
 
 static const char *strTestNetDNSSeed[][2] = {
     {"testnet-seed.reddcoin.com", "testnet-seed.reddcoin.com"},
+    {"testnet-dnsseed.redd.ink", "testnet-dnsseed.redd.ink"},
     {NULL, NULL}
 };
 

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -4,7 +4,7 @@
 
 #include "bitcoinamountfield.h"
 
-#include "util.h"
+// #include "util.h"
 #include "qvaluecombobox.h"
 #include "bitcoinunits.h"
 #include "guiconstants.h"
@@ -56,7 +56,8 @@ void BitcoinAmountField::setText(const QString &text)
     {
         // remove the space delimiter for every 3 digits
         QString value = text;
-        amount->setValue(value.replace(" ", "").toDouble());
+        value.replace(" ", "");
+        amount->setValue(value.toDouble());
     }
 }
 


### PR DESCRIPTION
- Fix for DER signature length Issue identified originally on Peercoin causing a fork of the blockchain
- Updated OpenSSL to 1.0.1k
- Updated install doc requirements
- Added extra DNSSeed nodes (main & testnet(potential))
- fixed compile error on Windows QT
